### PR TITLE
feat: Initial backend setup for chat and exchange features

### DIFF
--- a/backend_ojeda/asgi.py
+++ b/backend_ojeda/asgi.py
@@ -6,11 +6,30 @@ It exposes the ASGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
 """
+ASGI config for backend_ojeda project.
+
+It exposes the ASGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/5.1/howto/deployment/asgi/
+"""
 
 import os
-
 from django.core.asgi import get_asgi_application
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.auth import AuthMiddlewareStack
+import store.routing # We will create this file next
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend_ojeda.settings')
 
-application = get_asgi_application()
+# Get the default Django ASGI application to handle HTTP requests
+django_asgi_app = get_asgi_application()
+
+application = ProtocolTypeRouter({
+    "http": django_asgi_app,
+    "websocket": AuthMiddlewareStack(
+        URLRouter(
+            store.routing.websocket_urlpatterns
+        )
+    ),
+})

--- a/backend_ojeda/settings.py
+++ b/backend_ojeda/settings.py
@@ -54,6 +54,7 @@ CSRF_TRUSTED_ORIGINS = [
 # Application definition
 
 INSTALLED_APPS = [
+    'daphne',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -67,7 +68,58 @@ INSTALLED_APPS = [
     'rest_framework',
     'store',
     'graphene_django',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    'allauth.socialaccount.providers.google',
+    'allauth.socialaccount.providers.apple',
+    'dj_rest_auth',
+    'dj_rest_auth.registration',
+    'channels',
 ]
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend',
+    'allauth.account.auth_backends.AuthenticationBackend',
+)
+
+SITE_ID = 1
+
+ACCOUNT_AUTHENTICATION_METHOD = 'email'
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_UNIQUE_EMAIL = True
+ACCOUNT_USER_MODEL_USERNAME_FIELD = None
+ACCOUNT_USERNAME_REQUIRED = False
+ACCOUNT_EMAIL_VERIFICATION = 'none' # Can be set to 'mandatory' or 'optional'
+
+SOCIALACCOUNT_PROVIDERS = {
+    'google': {
+        'SCOPE': [
+            'profile',
+            'email',
+        ],
+        'AUTH_PARAMS': {
+            'access_type': 'online',
+        }
+    },
+    'apple': {
+        'SCOPE': [
+            'name',
+            'email'
+        ],
+        'LOGIN_PARAMS': { # Optional: Custom parameters for the authorization URL
+            'response_mode': 'form_post', # Or 'fragment' or 'query'
+        },
+        # You will need to configure your Apple App ID, Services ID, Team ID, Key ID, and private key
+        # 'APP': {
+        #    'client_id': 'your.service.id', # Services ID
+        #    'secret': 'YOUR_APPLE_PRIVATE_KEY_CONTENT_HERE', # Content of your .p8 key file
+        #    'key': 'YOUR_APPLE_KEY_ID', # Key ID
+        #    'certificate_key': None, # Or path to your .pem certificate if not using .p8
+        #    'team_id': 'YOUR_APPLE_TEAM_ID'
+        # }
+    }
+}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
@@ -75,6 +127,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
@@ -178,6 +231,13 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',
     ],
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'USE_JWT': True, # dj-rest-auth uses JWTs for authentication
+}
+
+REST_AUTH = {
+    'USE_JWT': True,
+    'JWT_AUTH_HTTPONLY': False, # Allow JWT to be accessed by JavaScript
+    'TOKEN_MODEL': None, # We are using JWTs, not DRF's Token model via dj_rest_auth
 }
 
 AUTH_USER_MODEL = 'store.Usuario'  # Asegúrate de que esto esté configurado
@@ -207,3 +267,17 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 GRAPHENE = {
     'SCHEMA': 'backend_ojeda.schema.schema'
 }
+
+ASGI_APPLICATION = 'backend_ojeda.asgi.application'
+
+# Stripe API Keys
+STRIPE_PUBLISHABLE_KEY = config('STRIPE_PUBLISHABLE_KEY', default='your_stripe_publishable_key')
+STRIPE_SECRET_KEY = config('STRIPE_SECRET_KEY', default='your_stripe_secret_key')
+STRIPE_WEBHOOK_SECRET = config('STRIPE_WEBHOOK_SECRET', default='your_stripe_webhook_secret') # For webhook verification
+
+# Binance API Keys (ensure these are for Binance Pay, not trading, if different)
+BINANCE_API_KEY = config('BINANCE_API_KEY', default='your_binance_api_key')
+BINANCE_SECRET_KEY = config('BINANCE_SECRET_KEY', default='your_binance_secret_key')
+# Depending on the Binance Pay API, you might need a merchant ID or other specific configs
+BINANCE_MERCHANT_ID = config('BINANCE_MERCHANT_ID', default='your_binance_merchant_id')
+BINANCE_PAY_BASE_URL = config('BINANCE_PAY_BASE_URL', default='https://bpay.binanceapi.com') # Example, verify actual

--- a/backend_ojeda/urls.py
+++ b/backend_ojeda/urls.py
@@ -31,4 +31,5 @@ urlpatterns = [
     path('schema/', SpectacularAPIView.as_view(), name='schema'), # This is for DRF Spectacular
     # GraphQL endpoint
     path("graphql", csrf_exempt(GraphQLView.as_view(graphiql=True, schema=gql_schema))),
+    path('accounts/', include('allauth.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,12 @@ threadpoolctl==3.5.0
 tzdata==2024.2
 uritemplate==4.1.1
 urllib3==2.3.0
+django-allauth==0.61.1
+dj-rest-auth==5.0.2 # Upgrading to a more recent version for better allauth compatibility
+stripe==8.5.0
+# Using a version that's likely compatible with current Django/Python
+# Check for latest stable version if setting up a new project
+python-binance==1.0.19 # For Binance API interactions
+channels==4.0.0 # For WebSocket support
+daphne==4.1.2 # ASGI server for Channels
+drf-nested-routers==0.93.4 # For nested API routes (e.g., room messages)

--- a/store/admin.py
+++ b/store/admin.py
@@ -73,9 +73,9 @@ class WalletAdmin(admin.ModelAdmin):
     list_filter = ('actualizado',)
 
 class PedidoAdmin(admin.ModelAdmin):
-    list_display = ('usuario', 'tienda', 'total', 'creado', 'pagado')
-    search_fields = ('usuario__username', 'tienda__nombre')
-    list_filter = ('creado', 'pagado')
+    list_display = ('usuario', 'tienda', 'total', 'creado', 'estado_pago', 'payment_intent_id', 'binance_order_id')
+    search_fields = ('usuario__username', 'tienda__nombre', 'payment_intent_id', 'binance_order_id')
+    list_filter = ('creado', 'estado_pago')
     change_list_template = "admin/analytics_change_list.html"
 
     def get_urls(self):

--- a/store/consumers.py
+++ b/store/consumers.py
@@ -1,0 +1,112 @@
+import json
+from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.db import database_sync_to_async # For database operations
+from .models import ChatRoom, ChatMessage, Usuario
+
+class ChatConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.room_name = self.scope['url_route']['kwargs']['room_name']
+        self.room_group_name = f'chat_{self.room_name}'
+        self.user = self.scope['user']
+
+        if not self.user.is_authenticated:
+            await self.close()
+            return
+
+        # Validate if room_name is a valid ChatRoom ID and user is a participant
+        # For simplicity, we'll assume room_name is the ID of the ChatRoom for now.
+        # A more robust approach might involve a UUID for room names or more complex lookup.
+        try:
+            self.chat_room_id = int(self.room_name)
+            self.chat_room = await self.get_chat_room(self.chat_room_id)
+            if self.chat_room is None or not await self.is_user_participant(self.chat_room, self.user):
+                await self.close()
+                return
+        except ValueError:
+            # Room name is not an integer ID
+            await self.close()
+            return
+
+        # Join room group
+        await self.channel_layer.group_add(
+            self.room_group_name,
+            self.channel_name
+        )
+        await self.accept()
+        print(f"User {self.user.username} connected to room {self.room_group_name}")
+
+    async def disconnect(self, close_code):
+        if hasattr(self, 'room_group_name'): # Ensure room_group_name was set
+            # Leave room group
+            await self.channel_layer.group_discard(
+                self.room_group_name,
+                self.channel_name
+            )
+            print(f"User {self.user.username if self.user.is_authenticated else 'Anonymous'} disconnected from room {self.room_group_name}")
+
+    # Receive message from WebSocket
+    async def receive(self, text_data):
+        if not self.user.is_authenticated:
+            return # Should not happen if connect() closed for unauthenticated
+
+        text_data_json = json.loads(text_data)
+        message_content = text_data_json.get('message')
+        message_type = text_data_json.get('message_type', ChatMessage.MESSAGE_TYPE_TEXT) # Default to text
+
+        if not message_content and message_type == ChatMessage.MESSAGE_TYPE_TEXT:
+            print("Received empty text message, ignoring.")
+            return
+
+        # Save message to database
+        chat_message = await self.save_message(self.chat_room, self.user, message_content, message_type)
+
+        # Send message to room group
+        await self.channel_layer.group_send(
+            self.room_group_name,
+            {
+                'type': 'chat_message_event', # This will call chat_message_event method
+                'message_id': chat_message.id,
+                'sender_id': self.user.id,
+                'sender_username': self.user.username,
+                'content': chat_message.content,
+                'timestamp': chat_message.timestamp.isoformat(),
+                'message_type': chat_message.message_type,
+            }
+        )
+        print(f"User {self.user.username} sent message to room {self.room_group_name}")
+
+
+    # Receive message from room group and send to WebSocket
+    async def chat_message_event(self, event):
+        # Send message to WebSocket
+        await self.send(text_data=json.dumps({
+            'id': event['message_id'],
+            'sender_id': event['sender_id'],
+            'sender_username': event['sender_username'],
+            'content': event['content'],
+            'timestamp': event['timestamp'],
+            'message_type': event['message_type'],
+        }))
+        print(f"Sent message event to WebSocket in room {self.room_group_name}")
+
+    @database_sync_to_async
+    def get_chat_room(self, room_id):
+        try:
+            return ChatRoom.objects.get(id=room_id)
+        except ChatRoom.DoesNotExist:
+            return None
+
+    @database_sync_to_async
+    def is_user_participant(self, room, user):
+        if not room or not user.is_authenticated:
+            return False
+        return room.participants.filter(id=user.id).exists()
+
+    @database_sync_to_async
+    def save_message(self, room, sender, content, message_type):
+        return ChatMessage.objects.create(
+            room=room,
+            sender=sender,
+            content=content,
+            message_type=message_type
+        )

--- a/store/models.py
+++ b/store/models.py
@@ -83,10 +83,23 @@ class Pedido(models.Model):
     items = models.ManyToManyField(ItemCarrito)
     total = models.DecimalField(max_digits=10, decimal_places=2)
     creado = models.DateTimeField(auto_now_add=True)
-    pagado = models.BooleanField(default=False)
+
+    STATUS_CHOICES = [
+        ('PENDING', 'Pending'),
+        ('PAID', 'Paid'),
+        ('FAILED', 'Failed'),
+        ('REFUNDED', 'Refunded'),
+    ]
+    estado_pago = models.CharField(max_length=10, choices=STATUS_CHOICES, default='PENDING')
+    payment_intent_id = models.CharField(max_length=100, blank=True, null=True) # For Stripe
+    binance_order_id = models.CharField(max_length=100, blank=True, null=True) # For Binance Pay
+
+    # Old 'pagado' field can be removed or kept for backward compatibility if needed
+    # For now, let's assume new logic uses 'estado_pago'
+    # pagado = models.BooleanField(default=False)
 
     def __str__(self):
-        return f"Pedido {self.id} de {self.usuario.username}"
+        return f"Pedido {self.id} de {self.usuario.username} - {self.estado_pago}"
 
 class Categoria(models.Model):
     nombre = models.CharField(max_length=100)
@@ -146,3 +159,88 @@ class Wallet(models.Model):
 
     def __str__(self):
         return f"Wallet de {self.usuario.username} - Saldo: {self.saldo}"
+
+# Chat Models
+class ChatRoom(models.Model):
+    participants = models.ManyToManyField(Usuario, related_name='chat_rooms')
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True) # To track last message time for sorting
+
+    def __str__(self):
+        return f"ChatRoom {self.id} ({self.participants.count()} participants)"
+
+class ChatMessage(models.Model):
+    MESSAGE_TYPE_TEXT = 'text'
+    MESSAGE_TYPE_PROPOSAL_INITIATE = 'proposal_initiate'
+    MESSAGE_TYPE_PROPOSAL_ACCEPT = 'proposal_accept'
+    MESSAGE_TYPE_PROPOSAL_REJECT = 'proposal_reject'
+    MESSAGE_TYPE_PROPOSAL_CANCEL = 'proposal_cancel' # Added cancel
+    MESSAGE_TYPE_PROPOSAL_COMPLETE = 'proposal_complete' # Added complete
+
+    MESSAGE_TYPES = [
+        (MESSAGE_TYPE_TEXT, 'Text'),
+        (MESSAGE_TYPE_PROPOSAL_INITIATE, 'Proposal Initiated'),
+        (MESSAGE_TYPE_PROPOSAL_ACCEPT, 'Proposal Accepted'),
+        (MESSAGE_TYPE_PROPOSAL_REJECT, 'Proposal Rejected'),
+        (MESSAGE_TYPE_PROPOSAL_CANCEL, 'Proposal Cancelled'),
+        (MESSAGE_TYPE_PROPOSAL_COMPLETE, 'Proposal Completed'),
+    ]
+
+    room = models.ForeignKey(ChatRoom, on_delete=models.CASCADE, related_name='messages')
+    sender = models.ForeignKey(Usuario, on_delete=models.CASCADE, related_name='sent_messages')
+    content = models.TextField(blank=True, null=True) # Can be null for non-text messages
+    timestamp = models.DateTimeField(auto_now_add=True)
+    message_type = models.CharField(max_length=20, choices=MESSAGE_TYPES, default=MESSAGE_TYPE_TEXT)
+    # related_proposal = models.ForeignKey('ExchangeProposal', null=True, blank=True, on_delete=models.SET_NULL, related_name='chat_messages')
+
+    def __str__(self):
+        return f"Message from {self.sender.username} in Room {self.room.id} at {self.timestamp}"
+
+    class Meta:
+        ordering = ['timestamp']
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        # Update the parent room's updated_at timestamp
+        self.room.updated_at = self.timestamp
+        self.room.save(update_fields=['updated_at'])
+
+
+class ExchangeProposal(models.Model):
+    STATUS_PENDING = 'pending'
+    STATUS_ACCEPTED = 'accepted'
+    STATUS_REJECTED = 'rejected'
+    STATUS_CANCELLED = 'cancelled' # User who proposed can cancel before acceptance
+    STATUS_COMPLETED = 'completed' # Both parties agree it's done
+
+    STATUS_CHOICES = [
+        (STATUS_PENDING, 'Pending'),
+        (STATUS_ACCEPTED, 'Accepted'),
+        (STATUS_REJECTED, 'Rejected'),
+        (STATUS_CANCELLED, 'Cancelled'),
+        (STATUS_COMPLETED, 'Completed'),
+    ]
+
+    chat_room = models.ForeignKey(ChatRoom, on_delete=models.CASCADE, related_name='exchange_proposals')
+    proposing_user = models.ForeignKey(Usuario, on_delete=models.CASCADE, related_name='made_proposals')
+    # Assuming for now that a proposal is about a 'Producto'.
+    # If it can be about a 'Service' or other models, GenericForeignKey might be better.
+    # Or, have separate fields like `proposed_product` and `proposed_service` (nullable).
+    proposed_product = models.ForeignKey(Producto, null=True, blank=True, on_delete=models.SET_NULL)
+    # proposed_service_description = models.TextField(null=True, blank=True) # If services are just text based for now
+
+    quantity = models.PositiveIntegerField(default=1, null=True, blank=True)
+    price = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True) # Price for the exchange, if any
+    terms = models.TextField(blank=True, null=True) # Additional terms or description of the exchange
+
+    status = models.CharField(max_length=15, choices=STATUS_CHOICES, default=STATUS_PENDING)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    # Link to the message that initiated this proposal
+    initiating_message = models.OneToOneField(ChatMessage, null=True, blank=True, on_delete=models.SET_NULL, related_name='initiated_proposal_in_message')
+
+
+    def __str__(self):
+        item_name = self.proposed_product.name if self.proposed_product else "Ad-hoc service/item"
+        return f"Proposal by {self.proposing_user.username} for '{item_name}' in Room {self.chat_room.id} - Status: {self.status}"

--- a/store/routing.py
+++ b/store/routing.py
@@ -1,0 +1,6 @@
+from django.urls import re_path
+from . import consumers # We will create consumers.py next
+
+websocket_urlpatterns = [
+    re_path(r'ws/chat/(?P<room_name>\w+)/$', consumers.ChatConsumer.as_asgi()),
+]

--- a/store/serializers.py
+++ b/store/serializers.py
@@ -1,5 +1,9 @@
 from rest_framework import serializers
-from .models import Producto, Categoria, ItemCarrito, Carrito, Pedido, Tienda, ProductoTienda, Comentario, ComentarioProducto, Referencia, Wallet, Usuario
+from .models import (
+    Producto, Categoria, ItemCarrito, Carrito, Pedido, Tienda, ProductoTienda,
+    Comentario, ComentarioProducto, Referencia, Wallet, Usuario,
+    ChatRoom, ChatMessage, ExchangeProposal # Added ExchangeProposal
+)
 
 class UsuarioSerializer(serializers.ModelSerializer):
     class Meta:
@@ -58,10 +62,83 @@ class CarritoSerializer(serializers.ModelSerializer):
 
 class PedidoSerializer(serializers.ModelSerializer):
     items = ItemCarritoSerializer(many=True, read_only=True)
+    # Ensure 'usuario' is read-only or handled appropriately if set by request.user
+    # For 'tienda', it might be set based on items or explicitly.
 
     class Meta:
         model = Pedido
-        fields = ['id', 'usuario', 'tienda', 'items', 'total', 'creado', 'pagado']
+        fields = [
+            'id', 'usuario', 'tienda', 'items', 'total', 'creado',
+            'estado_pago', 'payment_intent_id', 'binance_order_id'
+        ]
+        read_only_fields = ('usuario', 'total', 'estado_pago', 'payment_intent_id', 'binance_order_id')
+
+
+class ChatMessageSerializer(serializers.ModelSerializer):
+    sender_username = serializers.ReadOnlyField(source='sender.username')
+
+    class Meta:
+        model = ChatMessage
+        fields = ['id', 'room', 'sender', 'sender_username', 'content', 'timestamp', 'message_type']
+        read_only_fields = ('sender', 'timestamp', 'sender_username') # Room is set by URL or context
+
+class ChatRoomSerializer(serializers.ModelSerializer):
+    participants = UsuarioSerializer(many=True, read_only=True)
+    # last_message = ChatMessageSerializer(read_only=True) # Potentially heavy, consider a lighter version or method field
+    unread_count = serializers.SerializerMethodField() # Example: if you implement unread counts
+
+    class Meta:
+        model = ChatRoom
+        fields = ['id', 'participants', 'created_at', 'updated_at', 'unread_count'] # Add 'last_message' if you implement it
+        read_only_fields = ('created_at', 'updated_at')
+
+    def get_unread_count(self, obj):
+        # Placeholder: Actual unread count logic would be more complex
+        # e.g., based on a 'last_read_timestamp' per user per room.
+        # user = self.context['request'].user
+        # return ChatMessage.objects.filter(room=obj, timestamp__gt=user.last_read_in_room.get(obj.id, timezone.now()-timedelta(days=365))).count()
+        return 0
+
+class ExchangeProposalSerializer(serializers.ModelSerializer):
+    proposing_user_details = UsuarioSerializer(source='proposing_user', read_only=True)
+    proposed_product_details = ProductoSerializer(source='proposed_product', read_only=True)
+    # We need to make chat_room writeable for creation, but read_only for display might be through a nested URL.
+    # For creation, client will need to specify chat_room ID.
+
+    class Meta:
+        model = ExchangeProposal
+        fields = [
+            'id', 'chat_room', 'proposing_user', 'proposing_user_details',
+            'proposed_product', 'proposed_product_details', 'quantity', 'price', 'terms',
+            'status', 'created_at', 'updated_at', 'initiating_message'
+        ]
+        read_only_fields = ('proposing_user', 'status', 'created_at', 'updated_at', 'initiating_message', 'proposing_user_details', 'proposed_product_details')
+
+    def create(self, validated_data):
+        request = self.context.get('request')
+        proposing_user = request.user
+        chat_room = validated_data.get('chat_room')
+
+        # Validate that the proposing_user is a participant of the chat_room
+        if not chat_room.participants.filter(id=proposing_user.id).exists():
+            raise serializers.ValidationError("You are not a participant of this chat room and cannot make proposals.")
+
+        # Create the proposal
+        proposal = ExchangeProposal.objects.create(proposing_user=proposing_user, **validated_data)
+
+        # Optionally, create an initial ChatMessage of type 'proposal_initiate'
+        # This message can link to the proposal.
+        # chat_message = ChatMessage.objects.create(
+        #     room=chat_room,
+        #     sender=proposing_user,
+        #     message_type=ChatMessage.MESSAGE_TYPE_PROPOSAL_INITIATE,
+        #     content=f"Propuesta de intercambio: {proposal.proposed_product.name if proposal.proposed_product else 'item/servicio'}"
+        # )
+        # proposal.initiating_message = chat_message
+        # proposal.save()
+
+        # TODO: Trigger WebSocket notification about the new proposal (will be handled in a later step)
+        return proposal
 
 class TiendaSerializer(serializers.ModelSerializer):
     class Meta:

--- a/store/urls.py
+++ b/store/urls.py
@@ -1,10 +1,19 @@
 from django.urls import path, include
-from rest_framework.routers import DefaultRouter
+# from rest_framework.routers import DefaultRouter # Replaced by NestedDefaultRouter
+from rest_framework_nested.routers import DefaultRouter, NestedDefaultRouter
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
 )
-from .views import UsuarioViewSet, TiendaViewSet, ProductoTiendaViewSet, CarritoView, PedidoView, CategoriaViewSet, ProductoViewSet, ComentarioViewSet, ComentarioProductoViewSet, ReferenciaViewSet, WalletViewSet, WalletActionView, CreateUserView, UsuarioDetalleView
+from .views import (
+    UsuarioViewSet, TiendaViewSet, ProductoTiendaViewSet, CarritoView, PedidoView,
+    CategoriaViewSet, ProductoViewSet, ComentarioViewSet, ComentarioProductoViewSet,
+    ReferenciaViewSet, WalletViewSet, WalletActionView, CreateUserView, UsuarioDetalleView,
+    GoogleLogin, AppleLogin, StripeCreatePaymentIntentView, # stripe_webhook is imported directly
+    BinanceCreateOrderView, # binance_webhook is imported directly
+    ChatRoomViewSet, ChatMessageViewSet # Added Chat ViewSets
+)
+from .views import stripe_webhook, binance_webhook # Import webhooks directly
 
 router = DefaultRouter()
 router.register(r'usuarios', UsuarioViewSet)
@@ -16,12 +25,25 @@ router.register(r'comentarios', ComentarioViewSet)
 router.register(r'comentarios-producto', ComentarioProductoViewSet)
 router.register(r'referencias', ReferenciaViewSet)
 router.register(r'wallets', WalletViewSet)
+router.register(r'chat_rooms', ChatRoomViewSet, basename='chatroom')
+
+# Nested router for messages within a chat room
+# Generates URLs like: /api/store/app/chat_rooms/{room_pk}/messages/
+chat_rooms_router = NestedDefaultRouter(router, r'chat_rooms', lookup='room')
+chat_rooms_router.register(r'messages', ChatMessageViewSet, basename='chatroom-messages')
 
 urlpatterns = [
     path('app/', include(router.urls)),
+    path('app/', include(chat_rooms_router.urls)), # Include nested chat message routes
     path('register-user/', CreateUserView.as_view(), name='user-register'),  # Ruta para crear usuarios
     path('carrito/', CarritoView.as_view(), name='carrito'),
     path('pedidos/', PedidoView.as_view(), name='pedidos'),
     path('wallet-action/', WalletActionView.as_view(), name='wallet-action'),
     path('usuario-detalle/', UsuarioDetalleView.as_view(), name='usuario-detalle'),
+    path('auth/google/', GoogleLogin.as_view(), name='google_login'),
+    path('auth/apple/', AppleLogin.as_view(), name='apple_login'),
+    path('stripe/create-payment-intent/', StripeCreatePaymentIntentView.as_view(), name='stripe-create-payment-intent'),
+    path('stripe/webhook/', stripe_webhook, name='stripe-webhook'),
+    path('binance/create-order/', BinanceCreateOrderView.as_view(), name='binance-create-order'),
+    path('binance/webhook/', binance_webhook, name='binance-webhook'),
 ]

--- a/store/views.py
+++ b/store/views.py
@@ -198,3 +198,391 @@ class UsuarioDetalleView(APIView):
             response_data['tienda'] = tienda_data
 
         return Response(response_data, status=status.HTTP_200_OK)
+
+from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
+from allauth.socialaccount.providers.oauth2.client import OAuth2Client
+from dj_rest_auth.registration.views import SocialLoginView
+from rest_framework_simplejwt.tokens import RefreshToken
+
+class GoogleLogin(SocialLoginView):
+    adapter_class = GoogleOAuth2Adapter
+    client_class = OAuth2Client
+    callback_url = 'http://localhost:8000/accounts/google/login/callback/' # Update if necessary
+
+    def post(self, request, *args, **kwargs):
+        response = super().post(request, *args, **kwargs)
+        if response.status_code == 200:
+            user = self.user
+            refresh = RefreshToken.for_user(user)
+            return Response({
+                'refresh': str(refresh),
+                'access': str(refresh.access_token),
+                'user': UsuarioSerializer(user).data
+            })
+        return response
+
+from .models import ChatRoom, ChatMessage # Added
+from .serializers import ChatRoomSerializer, ChatMessageSerializer # Added
+from rest_framework.decorators import action # Added
+from django.db.models import Q, Max # Added for complex queries & ordering
+from rest_framework.pagination import PageNumberPagination # Added for message pagination
+
+class StandardResultsSetPagination(PageNumberPagination):
+    page_size = 20
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+
+class ChatRoomViewSet(viewsets.ModelViewSet):
+    serializer_class = ChatRoomSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_queryset(self):
+        # Users should only see chat rooms they are participants in
+        # Order by the 'updated_at' field of the ChatRoom, which is updated by new messages
+        return self.request.user.chat_rooms.annotate(
+            last_message_timestamp=Max('messages__timestamp')
+        ).order_by('-last_message_timestamp', '-updated_at')
+
+
+    def perform_create(self, serializer):
+        # Ensure the creating user is part of the participants
+        # The client should send a list of 'participant_ids'
+        participant_ids = self.request.data.get('participants', [])
+        participants = list(Usuario.objects.filter(id__in=participant_ids))
+
+        # Ensure the creator is in the participants list
+        if self.request.user not in participants:
+            participants.append(self.request.user)
+
+        # Prevent creating a room with only one participant (the creator)
+        if len(participants) < 2:
+            raise serializers.ValidationError("A chat room must have at least two participants.")
+
+        # Check if a room with these exact participants already exists to avoid duplicates
+        # This check can be complex for groups. For 1-on-1, it's simpler.
+        # For simplicity, we'll allow multiple rooms for same group for now, or client can check first.
+        # A more robust solution would involve a unique constraint or a more complex lookup.
+
+        chat_room = serializer.save()
+        chat_room.participants.set(participants)
+
+class ChatMessageViewSet(viewsets.ModelViewSet):
+    serializer_class = ChatMessageSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = StandardResultsSetPagination
+
+    def get_queryset(self):
+        # Filter messages by room_id provided in the URL (achieved via nested routing or query param)
+        # And ensure the user is a participant of that room.
+        room_id = self.kwargs.get('room_pk') # Assuming nested routing: /chat_rooms/{room_pk}/messages/
+        if not room_id:
+            # Fallback or error if room_id is not in URL (e.g. if using as a query parameter)
+            room_id_query = self.request.query_params.get('room_id')
+            if not room_id_query:
+                 return ChatMessage.objects.none() # Or raise an error
+            room_id = room_id_query
+
+
+        # Check if user is part of the room
+        if not ChatRoom.objects.filter(id=room_id, participants=self.request.user).exists():
+            return ChatMessage.objects.none() # Or raise PermissionDenied
+
+        return ChatMessage.objects.filter(room_id=room_id).order_by('-timestamp')
+
+    def perform_create(self, serializer):
+        # Message sending should ideally be via WebSockets for real-time.
+        # This HTTP endpoint can be a fallback or for specific message types not sent via WS.
+        room_id = self.request.data.get('room') # Expect room ID in request data
+
+        try:
+            room = ChatRoom.objects.get(id=room_id)
+            if not room.participants.filter(id=self.request.user.id).exists():
+                raise serializers.ValidationError("You are not a participant of this chat room.")
+        except ChatRoom.DoesNotExist:
+            raise serializers.ValidationError("ChatRoom not found.")
+
+        # The consumer will handle broadcasting. Here we just save.
+        # If using this endpoint to send, you might want to trigger a channel layer send manually:
+        # from channels.layers import get_channel_layer
+        # from asgiref.sync import async_to_sync
+        # channel_layer = get_channel_layer()
+        # async_to_sync(channel_layer.group_send)(...)
+
+        serializer.save(sender=self.request.user, room=room)
+
+import stripe
+from django.conf import settings
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+
+stripe.api_key = settings.STRIPE_SECRET_KEY
+
+class StripeCreatePaymentIntentView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        try:
+            pedido_id = request.data.get('pedido_id')
+            if not pedido_id:
+                return Response({'error': 'Pedido ID is required.'}, status=status.HTTP_400_BAD_REQUEST)
+
+            try:
+                pedido = Pedido.objects.get(id=pedido_id, usuario=request.user, estado_pago='PENDING')
+            except Pedido.DoesNotExist:
+                return Response({'error': 'Pedido no encontrado o ya procesado.'}, status=status.HTTP_404_NOT_FOUND)
+
+            # Amount in cents
+            amount = int(pedido.total * 100)
+
+            intent = stripe.PaymentIntent.create(
+                amount=amount,
+                currency='usd', # Or your desired currency
+                metadata={'pedido_id': pedido.id, 'user_id': request.user.id},
+                # automatic_payment_methods={'enabled': True}, # Recommended by Stripe
+            )
+
+            pedido.payment_intent_id = intent.id
+            pedido.save()
+
+            return Response({
+                'clientSecret': intent.client_secret,
+                'paymentIntentId': intent.id
+            }, status=status.HTTP_201_CREATED)
+
+        except stripe.error.StripeError as e:
+            return Response({'error': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            return Response({'error': 'An unexpected error occurred: ' + str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+@csrf_exempt
+def stripe_webhook(request):
+    payload = request.body
+    sig_header = request.META.get('HTTP_STRIPE_SIGNATURE')
+    endpoint_secret = settings.STRIPE_WEBHOOK_SECRET
+    event = None
+
+    try:
+        event = stripe.Webhook.construct_event(
+            payload, sig_header, endpoint_secret
+        )
+    except ValueError as e:
+        # Invalid payload
+        return HttpResponse(status=400)
+    except stripe.error.SignatureVerificationError as e:
+        # Invalid signature
+        return HttpResponse(status=400)
+
+    # Handle the event
+    if event.type == 'payment_intent.succeeded':
+        payment_intent = event.data.object
+        pedido_id = payment_intent.metadata.get('pedido_id')
+        try:
+            pedido = Pedido.objects.get(id=pedido_id, payment_intent_id=payment_intent.id)
+            pedido.estado_pago = 'PAID'
+            # Add any other post-payment logic here (e.g., send confirmation email, update inventory)
+            pedido.save()
+        except Pedido.DoesNotExist:
+            print(f"Webhook error: Pedido not found for payment_intent {payment_intent.id}")
+            return HttpResponse(status=404) # Or log and return 200 if Stripe should not retry
+
+    elif event.type == 'payment_intent.payment_failed':
+        payment_intent = event.data.object
+        pedido_id = payment_intent.metadata.get('pedido_id')
+        try:
+            pedido = Pedido.objects.get(id=pedido_id, payment_intent_id=payment_intent.id)
+            pedido.estado_pago = 'FAILED'
+            pedido.save()
+        except Pedido.DoesNotExist:
+            print(f"Webhook error: Pedido not found for payment_intent {payment_intent.id}")
+            # Potentially log this, but return 200 so Stripe doesn't retry for a pedido that might not exist.
+            return HttpResponse(status=200)
+
+    # ... handle other event types
+    else:
+        print('Unhandled event type {}'.format(event.type))
+
+    return HttpResponse(status=200)
+
+import time
+import hashlib
+import hmac
+import json
+import requests # Ensure requests is imported if not already
+
+class BinanceCreateOrderView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def _generate_signature(self, data_string):
+        return hmac.new(
+            settings.BINANCE_SECRET_KEY.encode('utf-8'),
+            data_string.encode('utf-8'),
+            hashlib.sha512
+        ).hexdigest().upper() # Binance Pay often uses SHA512, verify this
+
+    def post(self, request, *args, **kwargs):
+        pedido_id = request.data.get('pedido_id')
+        if not pedido_id:
+            return Response({'error': 'Pedido ID is required.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            pedido = Pedido.objects.get(id=pedido_id, usuario=request.user, estado_pago='PENDING')
+        except Pedido.DoesNotExist:
+            return Response({'error': 'Pedido no encontrado o ya procesado.'}, status=status.HTTP_404_NOT_FOUND)
+
+        # Construct payload for Binance Pay API - this is highly dependent on their API
+        # Refer to official Binance Pay "Create Order" API documentation
+        nonce = str(int(time.time() * 1000)) # Example nonce
+        payload_body = {
+            "env": {"terminalType": "APP"}, # Or "WEB", "WAP", "MINI_PROGRAM"
+            "merchantTradeNo": f"{pedido.id}_{nonce}", # Unique order ID for merchant
+            "orderAmount": str(pedido.total), # Amount as string
+            "currency": "USDT", # Or BUSD, etc. - currency supported by your Binance Pay account
+            "goodsDetails": [{ # Example, adjust as needed
+                "goodsType": "01", # 01: Tangible, 02: Virtual
+                "goodsCategory": "ECommerce",
+                "referenceGoodsId": str(p.producto.id),
+                "goodsName": p.producto.nombre,
+                # "goodsDetail": p.producto.descripcion # Optional
+            } for p in pedido.items.all()],
+            # "returnUrl": "your_app_return_url_after_payment", # Optional client-side redirect
+            # "notifyUrl": "your_backend_webhook_url_for_binance", # Important for server notifications
+            # ... other required parameters
+        }
+
+        # Binance API request structure: timestamp, nonce, signature in headers
+        # Body is JSON string. Signature is usually on (timestamp + nonce + request_body_string)
+        # This is a common pattern, VERIFY with Binance Pay docs.
+
+        timestamp = str(int(time.time() * 1000))
+        request_body_string = json.dumps(payload_body)
+        string_to_sign = f"{timestamp}\n{nonce}\n{request_body_string}\n"
+        signature = self._generate_signature(string_to_sign)
+
+        headers = {
+            'Content-Type': 'application/json',
+            'BinancePay-Timestamp': timestamp,
+            'BinancePay-Nonce': nonce,
+            'BinancePay-Certificate-SN': settings.BINANCE_API_KEY, # This is usually the API Key
+            'BinancePay-Signature': signature.upper()
+        }
+
+        try:
+            # Example endpoint, replace with actual Binance Pay Create Order API endpoint
+            # It's often something like /binancepay/openapi/v2/order or similar
+            api_url = f"{settings.BINANCE_PAY_BASE_URL}/binancepay/openapi/v1/order" # Verify exact endpoint
+
+            response = requests.post(api_url, headers=headers, data=request_body_string, timeout=10)
+            response.raise_for_status() # Raise an exception for HTTP errors
+
+            binance_response_data = response.json()
+
+            if binance_response_data.get('status') == 'SUCCESS':
+                # Store relevant info, e.g., binance's order ID (prepayId is common)
+                prepay_id = binance_response_data.get('data', {}).get('prepayId')
+                if not prepay_id:
+                     return Response({'error': 'Binance prepayId not found in response.'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+                pedido.binance_order_id = prepay_id
+                # Optionally store merchantTradeNo if you want to query by it later
+                # pedido.merchant_trade_no = payload_body["merchantTradeNo"]
+                pedido.save()
+
+                # The response to the client should include what's needed to launch Binance App/SDK
+                # This might be the `checkoutUrl` or other parameters from `binance_response_data.data`
+                return Response({
+                    'message': 'Binance order created successfully.',
+                    'binance_order_id': prepay_id,
+                    'checkout_details': binance_response_data.get('data') # Send relevant part to frontend
+                }, status=status.HTTP_201_CREATED)
+            else:
+                return Response({
+                    'error': 'Binance Pay API error.',
+                    'details': binance_response_data.get('errorMessage', 'Unknown error')
+                }, status=status.HTTP_400_BAD_REQUEST)
+
+        except requests.exceptions.RequestException as e:
+            return Response({'error': f'Binance API request failed: {str(e)}'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception as e:
+            return Response({'error': f'An unexpected error occurred: {str(e)}'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+@csrf_exempt
+def binance_webhook(request):
+    # Binance webhook security: verify signature (HMAC-SHA512 or similar)
+    # The exact mechanism depends on Binance Pay documentation.
+    # It typically involves checking a signature in headers against the payload and your secret key.
+
+    # Example: (This is a general idea, actual verification is critical and specific to Binance)
+    # received_signature = request.headers.get('Binancepay-Signature') # Or similar header
+    # payload_body = request.body.decode('utf-8')
+    # if not verify_binance_signature(payload_body, received_signature, settings.BINANCE_SECRET_KEY):
+    #     return HttpResponse('Invalid signature', status=400)
+
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return HttpResponse('Invalid JSON payload', status=400)
+
+    # Process the notification based on `bizStatus` or similar field
+    # E.g., "PAY_SUCCESS", "PAY_FAIL", "PAY_CLOSED"
+    biz_status = data.get('bizStatus')
+    # merchant_trade_no = data.get('merchantTradeNo') # Your unique order ID
+    prepay_id = data.get('prepayId') # Binance's transaction ID
+
+    if not prepay_id: # Or use merchant_trade_no if that's what you stored / can query by
+        print("Webhook error: prepayId not found in Binance notification.")
+        return HttpResponse('Missing prepayId', status=400)
+
+    try:
+        # Query using binance_order_id (prepayId)
+        pedido = Pedido.objects.get(binance_order_id=prepay_id)
+    except Pedido.DoesNotExist:
+        print(f"Webhook error: Pedido not found for Binance prepayId {prepay_id}")
+        # Return 200 to acknowledge receipt and prevent retries for non-existent orders
+        return HttpResponse('Pedido not found, acknowledged.', status=200)
+
+    if biz_status == 'PAY_SUCCESS':
+        pedido.estado_pago = 'PAID'
+        # Add other post-payment logic
+        pedido.save()
+        print(f"Pedido {pedido.id} marked as PAID via Binance webhook.")
+    elif biz_status in ['PAY_FAIL', 'PAY_CLOSED']: # Or other failure statuses
+        pedido.estado_pago = 'FAILED'
+        pedido.save()
+        print(f"Pedido {pedido.id} marked as FAILED via Binance webhook (status: {biz_status}).")
+    else:
+        print(f"Unhandled Binance webhook bizStatus: {biz_status} for pedido {pedido.id}")
+
+    # Binance expects a specific response format for success, usually JSON.
+    # Example: {"returnCode": "SUCCESS", "returnMessage": null}
+    # Consult Binance Pay documentation for the exact required response.
+    return HttpResponse(json.dumps({"returnCode": "SUCCESS", "returnMessage": None}), content_type='application/json', status=200)
+
+
+from allauth.socialaccount.providers.apple.views import AppleOAuth2Adapter
+
+class AppleLogin(SocialLoginView):
+    adapter_class = AppleOAuth2Adapter
+    client_class = OAuth2Client # Can reuse OAuth2Client
+    callback_url = 'http://localhost:8000/accounts/apple/login/callback/' # Update if necessary
+
+    def post(self, request, *args, **kwargs):
+        # The frontend should send 'id_token' and optionally 'code' from Apple
+        # dj_rest_auth SocialLoginView expects 'access_token' or 'code'
+        # We might need to adjust this if Apple provides the token differently
+        # For now, assuming the frontend can pass the id_token as 'access_token'
+        # or we might need a custom adapter if the flow is very different.
+
+        # If Apple sends 'id_token', we can rename it to 'access_token' for dj_rest_auth
+        if 'id_token' in request.data and 'access_token' not in request.data:
+            request.data['access_token'] = request.data['id_token']
+
+        response = super().post(request, *args, **kwargs)
+        if response.status_code == 200:
+            user = self.user
+            refresh = RefreshToken.for_user(user)
+            return Response({
+                'refresh': str(refresh),
+                'access': str(refresh.access_token),
+                'user': UsuarioSerializer(user).data
+            })
+        return response


### PR DESCRIPTION
- Defined Django models: ChatRoom, ChatMessage, ExchangeProposal.
- Updated Pedido model for new payment status fields.
- Configured Django Channels for WebSocket communication (ASGI, routing, basic ChatConsumer).
- Implemented DRF serializers and ViewSets for ChatRoom and ChatMessage, enabling API endpoints for listing rooms and messages (with pagination and nested routing).
- Added ExchangeProposalSerializer.
- Added dependencies: channels, daphne, drf-nested-routers.
- Resolved various configuration issues related to dj-rest-auth and django-allauth versioning and settings.
- Updated PedidoAdmin to align with model changes.

Work is currently paused midway through implementing the 'Backend: Exchange Proposal API Endpoints (DRF)' step. The ExchangeProposalSerializer has been created, but the corresponding ViewSet and URL routing are not yet implemented.